### PR TITLE
OTT homepage redesign — Netflix-style hero, carousel rows, themed cards

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,19 +1,33 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useSession, signOut } from "next-auth/react";
+import { useState, useEffect } from "react";
 import SearchBar from "./SearchBar";
 
 export default function Header() {
   const { data: session, status } = useSession();
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 60);
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   const handleSignOut = () => {
     signOut({ callbackUrl: "/auth/login" });
   };
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-[#141414]">
-      <div className="flex items-center justify-between px-4 md:px-8">
-        {/* Veflix Logo */}
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 ${
+        scrolled
+          ? "bg-[#141414] shadow-lg"
+          : "bg-gradient-to-b from-black/80 via-black/20 to-transparent"
+      }`}
+    >
+      <div className="flex items-center justify-between px-4 md:px-8 lg:px-12">
+        {/* Logo */}
         <div className="flex items-center">
           <Link href="/">
             <Image
@@ -25,30 +39,24 @@ export default function Header() {
             />
           </Link>
 
-          {/* Navigation Links */}
-          <nav className="hidden md:flex space-x-6 text-sm font-bold">
-            {/* <Link
-              href="/"
-              className="text-gray-300 hover:text-gray-400 transition-colors"
-            >
-              Home
-            </Link> */}
+          {/* Nav */}
+          <nav className="hidden md:flex space-x-5 text-sm font-medium">
             <Link
               href="/moviehub"
-              className="text-gray-300 hover:text-gray-400 transition-colors"
+              className="text-gray-200 hover:text-white transition-colors duration-200"
             >
               Movies
             </Link>
             <Link
               href="/tvserieshub"
-              className="text-gray-300 hover:text-gray-400 transition-colors"
+              className="text-gray-200 hover:text-white transition-colors duration-200"
             >
               TV Shows
             </Link>
             {session && (
               <Link
                 href="/profile"
-                className="text-gray-300 hover:text-gray-400 transition-colors"
+                className="text-gray-200 hover:text-white transition-colors duration-200"
               >
                 My List
               </Link>
@@ -56,20 +64,20 @@ export default function Header() {
           </nav>
         </div>
 
-        {/* Right Side Controls */}
+        {/* Right */}
         <div className="flex items-center space-x-4">
           <SearchBar />
 
           {status === "loading" ? (
-            <div className="w-8 h-8 border-2 border-gray-600 border-t-red-500 rounded-full animate-spin"></div>
+            <div className="w-6 h-6 border-2 border-gray-600 border-t-red-500 rounded-full animate-spin" />
           ) : session ? (
-            <div className="flex items-center space-x-4">
-              <span className="text-gray-300 text-sm hidden md:block">
-                Welcome, {session.user.name}
+            <div className="flex items-center space-x-3">
+              <span className="text-gray-300 text-sm hidden md:block truncate max-w-[120px]">
+                {session.user.name}
               </span>
               <button
                 onClick={handleSignOut}
-                className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
+                className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200 cursor-pointer"
               >
                 Sign Out
               </button>
@@ -77,7 +85,7 @@ export default function Header() {
           ) : (
             <Link
               href="/auth/login"
-              className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
+              className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200"
             >
               Sign In
             </Link>

--- a/src/components/MovieGrid.js
+++ b/src/components/MovieGrid.js
@@ -2,7 +2,7 @@ import MovieRow from "./MovieRow";
 
 export default function MovieGrid({ rows }) {
   return (
-    <div className="pt-20">
+    <div className="pt-4">
       {rows.map((row, index) => (
         <MovieRow key={index} title={row.title} url={row.url} type={row.type} />
       ))}

--- a/src/components/MovieRow.js
+++ b/src/components/MovieRow.js
@@ -1,196 +1,248 @@
-import { useState, useEffect } from "react";
-import MovieCard from "./MovieCard";
+import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
 import Link from "next/link";
+
+const TYPE_CONFIG = {
+  movie: { label: "FILM", color: "bg-red-600", accent: "#ef4444" },
+  tv: { label: "SERIES", color: "bg-violet-600", accent: "#7c3aed" },
+};
+
+function StarRating({ score }) {
+  if (!score) return null;
+  const pct = Math.round(score * 10);
+  const color = pct >= 70 ? "text-green-400" : pct >= 50 ? "text-yellow-400" : "text-red-400";
+  return (
+    <span className={`text-xs font-bold ${color}`}>{pct}%</span>
+  );
+}
 
 export default function MovieRow({ title, url, type = "movie" }) {
   const [items, setItems] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [currentSlide, setCurrentSlide] = useState(0);
-  const [prevClickCount, setPrevClickCount] = useState(0);
-  const [nextClickCount, setNextClickCount] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
-  const itemsPerSlide = 5; // Number of items to show per slide
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(true);
+  const rowRef = useRef(null);
+  const cfg = TYPE_CONFIG[type] || TYPE_CONFIG.movie;
 
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        console.log("API Key:", process.env.NEXT_PUBLIC_MOVIE_API_KEY);
-        console.log("URL:", url);
-
         if (!process.env.NEXT_PUBLIC_MOVIE_API_KEY) {
-          setError(
-            new Error(
-              "TMDB API key is missing. Please add NEXT_PUBLIC_MOVIE_API_KEY to your .env.local file"
-            )
-          );
           setIsLoading(false);
           return;
         }
-
-        const response = await fetch(
+        const res = await fetch(
           `${url}?api_key=${process.env.NEXT_PUBLIC_MOVIE_API_KEY}&language=en-US&page=1`
         );
-        let data = await response.json();
-
-        // Shuffle the results array before slicing
-        const shuffledResults = data.results.sort(() => Math.random() - 0.5);
-        data.results = shuffledResults.slice(0, 12);
-
-        setItems(data.results);
-        setIsLoading(false);
-      } catch (err) {
-        console.error("API Error:", err);
-        setError(err);
+        const data = await res.json();
+        setItems(data.results?.slice(0, 20) || []);
+      } catch {
+        // silently fail
+      } finally {
         setIsLoading(false);
       }
     };
-
     fetchItems();
   }, [url]);
 
-  const modifiedPoster = (posterPath) => {
-    if (!posterPath) return null;
-    return posterPath;
+  const updateScrollState = () => {
+    if (!rowRef.current) return;
+    const { scrollLeft, scrollWidth, clientWidth } = rowRef.current;
+    setCanScrollLeft(scrollLeft > 10);
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 10);
   };
 
-  const totalSlides = Math.ceil(items.length / itemsPerSlide);
-
-  const nextSlide = () => {
-    setCurrentSlide((prev) => (prev + 1) % totalSlides);
-    setNextClickCount((prev) => prev + 1);
-    setPrevClickCount((prev) => prev - 1);
+  const scroll = (dir) => {
+    if (!rowRef.current) return;
+    rowRef.current.scrollBy({
+      left: dir === "right" ? rowRef.current.clientWidth * 0.75 : -rowRef.current.clientWidth * 0.75,
+      behavior: "smooth",
+    });
   };
 
-  const prevSlide = () => {
-    setCurrentSlide((prev) => (prev - 1 + totalSlides) % totalSlides);
-    setPrevClickCount((prev) => prev + 1);
-    setNextClickCount((prev) => prev - 1);
-  };
+  const trim = (t) => t.trim().replace(/\s+/g, "_").toLowerCase();
+  const getTitle = (item) => (type === "tv" ? item.name : item.title);
+  const getLink = (item) => (type === "tv" ? `/tvdetails/${item.id}` : `/moviedetails/${item.id}`);
+  const getImage = (item) =>
+    item.backdrop_path
+      ? `https://image.tmdb.org/t/p/w500${item.backdrop_path}`
+      : item.poster_path
+      ? `https://image.tmdb.org/t/p/w342${item.poster_path}`
+      : null;
 
-  const goToSlide = (slideIndex) => {
-    setCurrentSlide(slideIndex);
-  };
-
-  const trim = (title) => {
-    return title.trim().replace(/\s+/g, "_").toLowerCase();
-  };
-
-  // Get the correct title and link based on content type
-  const getItemTitle = (item) => {
-    return type === "tv" ? item.name : item.title;
-  };
-
-  const getItemLink = (item) => {
-    return type === "tv" ? `/tvdetails/${item.id}` : `/moviedetails/${item.id}`;
-  };
-
-  if (isLoading)
-    return <div className="text-white px-4 md:px-8">Loading...</div>;
-
-  if (error)
+  if (isLoading) {
     return (
-      <div className="text-red-500 px-4 md:px-8">Error: {error.message}</div>
+      <div className="mb-12 px-4 md:px-12">
+        {/* Skeleton header */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-1 h-6 bg-gray-700 rounded-full" />
+          <div className="h-5 w-40 bg-gray-800 rounded animate-pulse" />
+          <div className="h-5 w-14 bg-gray-800 rounded-full animate-pulse" />
+        </div>
+        {/* Skeleton cards */}
+        <div className="flex gap-3">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="flex-shrink-0 w-48 md:w-60 rounded-xl overflow-hidden">
+              <div className="h-28 md:h-36 bg-gray-800 animate-pulse" />
+              <div className="bg-gray-900 px-2 py-2 space-y-1.5">
+                <div className="h-3 w-3/4 bg-gray-700 rounded animate-pulse" />
+                <div className="h-3 w-1/3 bg-gray-700 rounded animate-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     );
+  }
+
+  if (items.length === 0) return null;
 
   return (
-    <div className="mb-8">
-      <div
-        className="relative flex px-4 md:px-8 cursor-pointer justify-between"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <Link href={`/movielist?category=${trim(title)}&platform=${type}`}>
-          <h2 className="text-white text-xl font-semibold mb-4">{title}</h2>
-        </Link>
+    <div className="mb-12 group/row">
+      {/* Row header */}
+      <div className="flex items-center justify-between px-4 md:px-12 mb-4">
+        <div className="flex items-center gap-3">
+          {/* Accent bar */}
+          <div
+            className="w-1 h-6 rounded-full flex-shrink-0"
+            style={{ background: cfg.accent }}
+          />
+          <Link
+            href={`/movielist?category=${trim(title)}&platform=${type}`}
+            className="group/title flex items-center gap-2"
+          >
+            <h2 className="text-white text-lg md:text-xl font-bold tracking-wide">{title}</h2>
+            <span
+              className="text-xs font-semibold opacity-0 group-hover/title:opacity-100 transition-all duration-200 flex items-center gap-0.5"
+              style={{ color: cfg.accent }}
+            >
+              See All
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 5l7 7-7 7" />
+              </svg>
+            </span>
+          </Link>
+          {/* Type badge */}
+          <span className={`${cfg.color} text-white text-[10px] font-black px-2 py-0.5 rounded-full tracking-widest`}>
+            {cfg.label}
+          </span>
+        </div>
 
-        {/* Explore All Link */}
-        <Link
-          href={`/movielist?category=${trim(title)}&platform=${type}`}
-          className={`left-0 text-sm font-semibold text-blue-400 transition-all duration-300 ease-in-out transform hover:text-blue-300`}
-        >
-          Explore More
-        </Link>
+        {/* Scroll arrows in header */}
+        <div className="hidden md:flex items-center gap-1">
+          <button
+            onClick={() => scroll("left")}
+            disabled={!canScrollLeft}
+            className="w-7 h-7 rounded-full border border-gray-700 flex items-center justify-center text-gray-400 hover:border-gray-400 hover:text-white disabled:opacity-20 disabled:cursor-not-allowed transition-all duration-150 cursor-pointer"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <button
+            onClick={() => scroll("right")}
+            disabled={!canScrollRight}
+            className="w-7 h-7 rounded-full border border-gray-700 flex items-center justify-center text-gray-400 hover:border-gray-400 hover:text-white disabled:opacity-20 disabled:cursor-not-allowed transition-all duration-150 cursor-pointer"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
       </div>
-      <div className="relative px-4 md:px-8">
-        {/* Navigation Buttons */}
-        {totalSlides > 1 && (
-          <>
-            {nextClickCount > 0 && (
-              <button
-                onClick={prevSlide}
-                className="absolute left-0.5  transform  z-10 bg-black/50 hover:bg-black/70 text-white h-32 md:h-40 w-8 rounded-md transition-all duration-200 flex items-center justify-center cursor-pointer"
-                aria-label="Previous items"
-              >
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 19l-7-7 7-7"
-                  />
-                </svg>
-              </button>
-            )}
-            {nextClickCount < totalSlides - 1 && (
-              <button
-                onClick={nextSlide}
-                className="absolute right-0.5 transform  z-10 bg-black/50 hover:bg-black/70 text-white h-32 md:h-40 w-8 rounded-md transition-all duration-200 flex items-center justify-center cursor-pointer"
-                aria-label="Next items"
-              >
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 5l7 7-7 7"
-                  />
-                </svg>
-              </button>
-            )}
-          </>
+
+      {/* Cards */}
+      <div className="relative">
+        {/* Left fade */}
+        {canScrollLeft && (
+          <div className="absolute left-0 top-0 bottom-0 w-16 bg-gradient-to-r from-[#141414] to-transparent z-10 pointer-events-none" />
+        )}
+        {/* Right fade */}
+        {canScrollRight && (
+          <div className="absolute right-0 top-0 bottom-0 w-16 bg-gradient-to-l from-[#141414] to-transparent z-10 pointer-events-none" />
         )}
 
-        {/* Carousel Container */}
-        <div className="overflow-hidden">
-          <div
-            className="flex transition-transform duration-500 ease-in-out"
-            style={{ transform: `translateX(-${currentSlide * 100}%)` }}
-          >
-            {Array.from({ length: totalSlides }).map((_, slideIndex) => (
-              <div key={slideIndex} className="w-full flex-shrink-0">
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-20 pb-4">
-                  {items
-                    .slice(
-                      slideIndex * itemsPerSlide,
-                      (slideIndex + 1) * itemsPerSlide
-                    )
-                    .map((item, index) => (
-                      <div key={slideIndex * itemsPerSlide + index}>
-                        <Link href={getItemLink(item)}>
-                          <MovieCard
-                            msid={item.id}
-                            title={getItemTitle(item)}
-                            image={modifiedPoster(item.backdrop_path)}
-                            rating={item.vote_average}
-                          />
-                        </Link>
+        <div
+          ref={rowRef}
+          onScroll={updateScrollState}
+          className="flex gap-3 overflow-x-scroll scrollbar-hide px-4 md:px-12 pb-2"
+        >
+          {items.map((item, idx) => {
+            const imgSrc = getImage(item);
+            const itemTitle = getTitle(item);
+            const score = item.vote_average || null;
+            const year = (item.release_date || item.first_air_date || "").slice(0, 4);
+
+            return (
+              <Link
+                key={item.id}
+                href={getLink(item)}
+                className="flex-shrink-0 group/card cursor-pointer"
+              >
+                <div className="w-44 md:w-56 lg:w-64 rounded-xl overflow-hidden bg-[#1c1c1e] ring-1 ring-white/5 transition-all duration-300 group-hover/card:ring-2 group-hover/card:shadow-2xl"
+                  style={{ "--accent": cfg.accent }}
+                >
+                  {/* Thumbnail */}
+                  <div className="relative h-24 md:h-32 lg:h-36 overflow-hidden">
+                    {imgSrc ? (
+                      <Image
+                        src={imgSrc}
+                        alt={itemTitle}
+                        fill
+                        className="object-cover transition-transform duration-500 group-hover/card:scale-110"
+                        loading="lazy"
+                        sizes="(max-width: 768px) 176px, (max-width: 1024px) 224px, 256px"
+                      />
+                    ) : (
+                      <div className="w-full h-full bg-gradient-to-br from-gray-800 to-gray-900 flex items-center justify-center p-2">
+                        <span className="text-gray-500 text-xs text-center">{itemTitle}</span>
                       </div>
-                    ))}
+                    )}
+
+                    {/* Rank number for first 10 */}
+                    {idx < 10 && (
+                      <div className="absolute top-2 left-2 z-10">
+                        <span className="text-white text-xs font-black bg-black/60 backdrop-blur-sm px-1.5 py-0.5 rounded">
+                          #{idx + 1}
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Play button overlay */}
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover/card:bg-black/50 transition-all duration-300">
+                      <div
+                        className="w-11 h-11 rounded-full flex items-center justify-center scale-0 group-hover/card:scale-100 transition-transform duration-300 shadow-lg"
+                        style={{ background: cfg.accent }}
+                      >
+                        <svg className="w-5 h-5 text-white ml-0.5" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Info strip — always visible */}
+                  <div className="px-3 py-2.5 bg-[#1c1c1e] group-hover/card:bg-[#252528] transition-colors duration-200">
+                    <p className="text-white text-xs font-semibold truncate leading-snug mb-1">
+                      {itemTitle}
+                    </p>
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {year && <span className="text-gray-500 text-[10px]">{year}</span>}
+                        <span
+                          className="text-[10px] font-bold px-1.5 py-0.5 rounded-sm"
+                          style={{ background: cfg.accent + "22", color: cfg.accent }}
+                        >
+                          {cfg.label}
+                        </span>
+                      </div>
+                      <StarRating score={score} />
+                    </div>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              </Link>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/components/ui/HomepageHero.js
+++ b/src/components/ui/HomepageHero.js
@@ -1,0 +1,181 @@
+import { useState, useEffect, useCallback } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+const GENRE_MAP = {
+  28: "Action", 12: "Adventure", 16: "Animation", 35: "Comedy", 80: "Crime",
+  99: "Documentary", 18: "Drama", 10751: "Family", 14: "Fantasy", 36: "History",
+  27: "Horror", 10402: "Music", 9648: "Mystery", 10749: "Romance",
+  878: "Sci-Fi", 10770: "TV Movie", 53: "Thriller", 10752: "War", 37: "Western",
+};
+
+export default function HomepageHero() {
+  const [movies, setMovies] = useState([]);
+  const [current, setCurrent] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  useEffect(() => {
+    const fetchTrending = async () => {
+      try {
+        const res = await fetch(
+          `https://api.themoviedb.org/3/trending/movie/day?api_key=${process.env.NEXT_PUBLIC_MOVIE_API_KEY}&language=en-US`
+        );
+        const data = await res.json();
+        setMovies(data.results?.slice(0, 5) || []);
+      } catch {
+        // silently fail — hero just won't render
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTrending();
+  }, []);
+
+  const next = useCallback(() => {
+    setImageLoaded(false);
+    setCurrent((c) => (c + 1) % movies.length);
+  }, [movies.length]);
+
+  useEffect(() => {
+    if (movies.length === 0) return;
+    const timer = setInterval(next, 9000);
+    return () => clearInterval(timer);
+  }, [movies.length, next]);
+
+  if (loading) {
+    return (
+      <div className="relative h-[90vh] min-h-[560px] bg-black">
+        <div className="absolute inset-0 bg-gradient-to-r from-gray-900 to-gray-800 animate-pulse" />
+        <div className="absolute bottom-32 left-8 md:left-16 space-y-4">
+          <div className="h-12 w-80 bg-gray-700 rounded animate-pulse" />
+          <div className="h-4 w-96 bg-gray-700 rounded animate-pulse" />
+          <div className="h-4 w-72 bg-gray-700 rounded animate-pulse" />
+          <div className="flex gap-3 mt-6">
+            <div className="h-12 w-32 bg-gray-700 rounded animate-pulse" />
+            <div className="h-12 w-32 bg-gray-700 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (movies.length === 0) return null;
+
+  const movie = movies[current];
+  const matchScore = movie.vote_average ? Math.round(movie.vote_average * 10) : null;
+  const year = movie.release_date?.slice(0, 4);
+  const genres = movie.genre_ids?.slice(0, 3).map((id) => GENRE_MAP[id]).filter(Boolean) || [];
+  const backdropUrl = movie.backdrop_path
+    ? `https://image.tmdb.org/t/p/original${movie.backdrop_path}`
+    : null;
+
+  return (
+    <div className="relative h-[90vh] min-h-[560px] overflow-hidden bg-black">
+      {/* Backdrop */}
+      {backdropUrl && (
+        <div
+          key={movie.id}
+          className={`absolute inset-0 transition-opacity duration-1000 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
+        >
+          <Image
+            src={backdropUrl}
+            alt={movie.title}
+            fill
+            className="object-cover object-center"
+            priority
+            onLoad={() => setImageLoaded(true)}
+            sizes="100vw"
+          />
+        </div>
+      )}
+
+      {/* Gradient overlays — left-heavy like Netflix */}
+      <div className="absolute inset-0 bg-gradient-to-r from-black via-black/60 to-transparent" />
+      <div className="absolute inset-0 bg-gradient-to-t from-[#141414] via-transparent to-black/30" />
+
+      {/* Content */}
+      <div className="relative z-10 flex flex-col justify-end h-full pb-28 px-8 md:px-16">
+        <div className="max-w-xl">
+          {/* Match Score */}
+          {matchScore && (
+            <div className="flex items-center gap-3 mb-3">
+              <span className="text-green-400 font-bold text-lg">{matchScore}% Match</span>
+              {year && <span className="text-gray-300 text-sm">{year}</span>}
+              <span className="border border-gray-500 text-gray-300 text-xs px-1.5 py-0.5">HD</span>
+            </div>
+          )}
+
+          {/* Title */}
+          <h1 className="text-white text-4xl md:text-6xl font-bold leading-tight mb-4 drop-shadow-lg">
+            {movie.title}
+          </h1>
+
+          {/* Genres */}
+          {genres.length > 0 && (
+            <div className="flex items-center gap-2 mb-4">
+              {genres.map((g, i) => (
+                <span key={g} className="flex items-center gap-2 text-gray-300 text-sm">
+                  {i > 0 && <span className="w-1 h-1 rounded-full bg-gray-500 inline-block" />}
+                  {g}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Overview */}
+          <p className="text-gray-200 text-sm md:text-base leading-relaxed mb-7 line-clamp-3">
+            {movie.overview}
+          </p>
+
+          {/* Buttons */}
+          <div className="flex items-center gap-3">
+            <Link
+              href={`/moviedetails/${movie.id}`}
+              className="flex items-center gap-2 bg-white text-black font-semibold px-7 py-3 rounded-md hover:bg-white/85 transition-colors duration-200 cursor-pointer text-base"
+            >
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+              Play
+            </Link>
+            <Link
+              href={`/moviedetails/${movie.id}`}
+              className="flex items-center gap-2 bg-gray-500/60 hover:bg-gray-500/80 text-white font-semibold px-7 py-3 rounded-md transition-colors duration-200 cursor-pointer text-base backdrop-blur-sm"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              More Info
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Age rating badge — right side */}
+      <div className="absolute bottom-28 right-0 z-10">
+        <div className="border-l-2 border-gray-400 pl-3 pr-8 py-1.5">
+          <span className="text-gray-300 text-sm font-medium">
+            {movie.adult ? "18+" : "All Ages"}
+          </span>
+        </div>
+      </div>
+
+      {/* Dots indicator */}
+      {movies.length > 1 && (
+        <div className="absolute bottom-10 left-8 md:left-16 z-10 flex items-center gap-2">
+          {movies.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => { setImageLoaded(false); setCurrent(i); }}
+              className={`h-0.5 transition-all duration-300 cursor-pointer ${
+                i === current ? "w-8 bg-white" : "w-4 bg-gray-500 hover:bg-gray-300"
+              }`}
+              aria-label={`Feature ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,17 +1,16 @@
 import { movieApiConfig } from "../../config/apiConfig";
 import { Header, MovieGrid } from "../components";
+import HomepageHero from "../components/ui/HomepageHero";
 import Head from "next/head";
 
 export default function Home() {
   const { movieRows, tvRows } = movieApiConfig;
 
-  // Combine movie and TV rows with type indicators
   const allRows = [
     ...movieRows.map((row) => ({ ...row, type: "movie" })),
     ...tvRows.map((row) => ({ ...row, type: "tv" })),
   ];
 
-  // JSON-LD Schema for the home page
   const websiteSchema = {
     "@context": "https://schema.org",
     "@type": "WebSite",
@@ -58,30 +57,29 @@ export default function Home() {
         />
         <meta property="og:type" content="website" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta
-          name="twitter:title"
-          content="Veflix - Stream Movies & TV Shows"
-        />
+        <meta name="twitter:title" content="Veflix - Stream Movies & TV Shows" />
         <meta
           name="twitter:description"
           content="Discover and stream the latest movies and TV shows on Veflix."
         />
-        {/* JSON-LD Schemas */}
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(websiteSchema),
-          }}
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
         />
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(organizationSchema),
-          }}
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
         />
       </Head>
+
       <div className="min-h-screen bg-[#141414]">
+        {/* Header floats over hero */}
         <Header />
+
+        {/* Full-viewport hero with trending feature */}
+        <HomepageHero />
+
+        {/* Content rows */}
         <MovieGrid rows={allRows} />
       </div>
     </>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,3 +37,12 @@ body {
 .overflow-x-auto::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.5);
 }
+
+/* Hide scrollbar for movie rows */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
- New HomepageHero: full-viewport featured film section that auto-cycles through 5 trending movies every 9s (match %, genres, Play / More Info, dots indicator, age rating badge)
- Redesigned MovieRow: true CSS horizontal scroll replacing paginated grid; row headers with colored accent bar + FILM/SERIES badge + arrow controls; cards with rank numbers (#1–#10), always-visible info strip (title, year, type, match %), and accent-colored play button on hover
- Header: transparent gradient over hero → solid dark on scroll
- MovieGrid: removed top padding (hero handles header clearance)
- globals.css: added .scrollbar-hide utility