### PR TITLE
Fix mobile card overflow in watchlist grid on profile page

### DIFF
--- a/src/components/MovieCard.js
+++ b/src/components/MovieCard.js
@@ -44,11 +44,15 @@ export default function MovieCard({
     <div className="relative group cursor-pointer transition-transform duration-200 hover:scale-105">
       {/* Movie Thumbnail */}
       <div
-        className="relative bg-gray-800 rounded overflow-hidden"
-        style={{
-          width: `${IMAGE_CONFIG.SIZES[imageType][imageSize].width}px`,
-          height: `${IMAGE_CONFIG.SIZES[imageType][imageSize].height}px`,
-        }}
+        className={`relative bg-gray-800 rounded overflow-hidden${forList ? " w-full aspect-[2/3]" : ""}`}
+        style={
+          forList
+            ? undefined
+            : {
+                width: `${IMAGE_CONFIG.SIZES[imageType][imageSize].width}px`,
+                height: `${IMAGE_CONFIG.SIZES[imageType][imageSize].height}px`,
+              }
+        }
       >
         {/* Background Image */}
         {cardImageUrl ? (
@@ -56,7 +60,7 @@ export default function MovieCard({
             <Image
               src={cardImageUrl}
               alt={movieTitle}
-              {...imageProps}
+              {...(forList ? { fill: true } : imageProps)}
               className="object-cover"
               loading="lazy"
               placeholder="blur"


### PR DESCRIPTION
MovieCard used fixed pixel dimensions (300×450px) even when rendered in the profile watchlist grid, causing cards to overflow on mobile where the 3-column grid can't fit 300px-wide items.

When forList=true, the card container now uses w-full + aspect-[2/3] to fill its grid cell fluidly, and the Image switches to fill mode to match. Fixed-pixel sizing is preserved for all non-list usages.