### PR TITLE
Improve homepage LCP by moving hero fetch to SSR

### DIFF
--- a/src/components/ui/HomepageHero.js
+++ b/src/components/ui/HomepageHero.js
@@ -9,28 +9,9 @@ const GENRE_MAP = {
   878: "Sci-Fi", 10770: "TV Movie", 53: "Thriller", 10752: "War", 37: "Western",
 };
 
-export default function HomepageHero() {
-  const [movies, setMovies] = useState([]);
+export default function HomepageHero({ movies = [] }) {
   const [current, setCurrent] = useState(0);
-  const [loading, setLoading] = useState(true);
   const [imageLoaded, setImageLoaded] = useState(false);
-
-  useEffect(() => {
-    const fetchTrending = async () => {
-      try {
-        const res = await fetch(
-          `https://api.themoviedb.org/3/trending/movie/day?api_key=${process.env.NEXT_PUBLIC_MOVIE_API_KEY}&language=en-US`
-        );
-        const data = await res.json();
-        setMovies(data.results?.slice(0, 5) || []);
-      } catch {
-        // silently fail — hero just won't render
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchTrending();
-  }, []);
 
   const next = useCallback(() => {
     setImageLoaded(false);
@@ -43,23 +24,6 @@ export default function HomepageHero() {
     return () => clearInterval(timer);
   }, [movies.length, next]);
 
-  if (loading) {
-    return (
-      <div className="relative h-[90vh] min-h-[560px] bg-black">
-        <div className="absolute inset-0 bg-gradient-to-r from-gray-900 to-gray-800 animate-pulse" />
-        <div className="absolute bottom-32 left-8 md:left-16 space-y-4">
-          <div className="h-12 w-80 bg-gray-700 rounded animate-pulse" />
-          <div className="h-4 w-96 bg-gray-700 rounded animate-pulse" />
-          <div className="h-4 w-72 bg-gray-700 rounded animate-pulse" />
-          <div className="flex gap-3 mt-6">
-            <div className="h-12 w-32 bg-gray-700 rounded animate-pulse" />
-            <div className="h-12 w-32 bg-gray-700 rounded animate-pulse" />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   if (movies.length === 0) return null;
 
   const movie = movies[current];
@@ -67,7 +31,7 @@ export default function HomepageHero() {
   const year = movie.release_date?.slice(0, 4);
   const genres = movie.genre_ids?.slice(0, 3).map((id) => GENRE_MAP[id]).filter(Boolean) || [];
   const backdropUrl = movie.backdrop_path
-    ? `https://image.tmdb.org/t/p/original${movie.backdrop_path}`
+    ? `https://image.tmdb.org/t/p/w1280${movie.backdrop_path}`
     : null;
 
   return (

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -9,6 +9,8 @@ export default function Document() {
           name="google-site-verification"
           content="pQH2VBMFygWO9jNz_BqI7Fmk-OjZKryRJ3o5mnhB5uk"
         />
+        <link rel="preconnect" href="https://image.tmdb.org" />
+        <link rel="preconnect" href="https://api.themoviedb.org" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
         <link

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,7 +3,19 @@ import { Header, MovieGrid } from "../components";
 import HomepageHero from "../components/ui/HomepageHero";
 import Head from "next/head";
 
-export default function Home() {
+export async function getServerSideProps() {
+  try {
+    const res = await fetch(
+      `https://api.themoviedb.org/3/trending/movie/day?api_key=${process.env.NEXT_PUBLIC_MOVIE_API_KEY}&language=en-US`
+    );
+    const data = await res.json();
+    return { props: { heroMovies: data.results?.slice(0, 5) ?? [] } };
+  } catch {
+    return { props: { heroMovies: [] } };
+  }
+}
+
+export default function Home({ heroMovies }) {
   const { movieRows, tvRows } = movieApiConfig;
 
   const allRows = [
@@ -77,7 +89,7 @@ export default function Home() {
         <Header />
 
         {/* Full-viewport hero with trending feature */}
-        <HomepageHero />
+        <HomepageHero movies={heroMovies} />
 
         {/* Content rows */}
         <MovieGrid rows={allRows} />


### PR DESCRIPTION
- Add getServerSideProps to fetch trending movies server-side so the hero backdrop URL is embedded in initial HTML, eliminating the JS→fetch→setState→render waterfall (primary cause of 4.6s LCP)
- Refactor HomepageHero to accept movies as a prop; remove client-side fetch, loading state, and skeleton UI
- Switch backdrop image size from /original to /w1280 to reduce payload
- Add preconnect hints for image.tmdb.org and api.themoviedb.org