### PR TITLE
feat: track trailer completion and add Continue Watching carousel

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,7 @@ model TrailerWatch {
   mediaType String   // "movie" | "tv"
   title     String
   poster    String?
+  completed Boolean  @default(false)
   watchedAt DateTime @default(now()) @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/components/ui/ContinueWatchingCarousel.js
+++ b/src/components/ui/ContinueWatchingCarousel.js
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState } from "react";
+import { useSession } from "next-auth/react";
+import Image from "next/image";
+import Link from "next/link";
+
+function PlayIcon() {
+  return (
+    <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M8 5v14l11-7L8 5z" />
+    </svg>
+  );
+}
+
+function ChevronLeft() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+    </svg>
+  );
+}
+
+function ChevronRight() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+const POSTER_BASE = "https://image.tmdb.org/t/p/w342";
+
+export default function ContinueWatchingCarousel() {
+  const { data: session } = useSession();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const scrollRef = useRef(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  useEffect(() => {
+    if (!session?.user) { setLoading(false); return; }
+    fetch("/api/trailerHistory?status=incomplete")
+      .then((r) => r.json())
+      .then((d) => setItems(d.items ?? []))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [session]);
+
+  const updateScrollButtons = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 4);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+  };
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollButtons();
+    el.addEventListener("scroll", updateScrollButtons, { passive: true });
+    window.addEventListener("resize", updateScrollButtons);
+    return () => {
+      el.removeEventListener("scroll", updateScrollButtons);
+      window.removeEventListener("resize", updateScrollButtons);
+    };
+  }, [items]);
+
+  const scroll = (dir) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * 320, behavior: "smooth" });
+  };
+
+  if (!session?.user || (!loading && items.length === 0)) return null;
+
+  return (
+    <section className="px-4 md:px-8 py-6">
+      {/* Section header */}
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex items-center gap-2">
+          <span className="w-1 h-5 rounded-full bg-amber-500 inline-block" />
+          <h2 className="text-lg font-bold text-white tracking-tight">Continue Watching</h2>
+        </div>
+        <Link
+          href="/profile"
+          className="ml-auto text-xs text-gray-500 hover:text-amber-400 transition-colors duration-200 cursor-pointer"
+        >
+          See all
+        </Link>
+      </div>
+
+      {/* Carousel track */}
+      <div className="relative group/carousel">
+        {/* Left arrow */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll(-1)}
+            aria-label="Scroll left"
+            className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-3 z-10 w-9 h-9 rounded-full bg-black/80 border border-white/10 flex items-center justify-center text-white hover:bg-black hover:border-amber-500/50 transition-all duration-200 cursor-pointer shadow-xl"
+          >
+            <ChevronLeft />
+          </button>
+        )}
+
+        {/* Right arrow */}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll(1)}
+            aria-label="Scroll right"
+            className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-3 z-10 w-9 h-9 rounded-full bg-black/80 border border-white/10 flex items-center justify-center text-white hover:bg-black hover:border-amber-500/50 transition-all duration-200 cursor-pointer shadow-xl"
+          >
+            <ChevronRight />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-3 overflow-x-auto scrollbar-hide pb-1"
+          style={{ scrollSnapType: "x mandatory" }}
+        >
+          {loading
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex-none w-32 sm:w-36 aspect-[2/3] rounded-xl bg-white/5 animate-pulse"
+                  style={{ scrollSnapAlign: "start" }}
+                />
+              ))
+            : items.map((item) => {
+                const href =
+                  item.mediaType === "tv"
+                    ? `/tvdetails/${item.tmdbId}`
+                    : `/moviedetails/${item.tmdbId}`;
+                const posterSrc = item.poster ? `${POSTER_BASE}${item.poster}` : null;
+
+                return (
+                  <Link
+                    key={item.id}
+                    href={href}
+                    className="flex-none w-32 sm:w-36 group cursor-pointer"
+                    style={{ scrollSnapAlign: "start" }}
+                  >
+                    <div className="relative aspect-[2/3] rounded-xl overflow-hidden ring-1 ring-white/5 transition-all duration-300 group-hover:ring-amber-500/60 group-hover:scale-[1.03] group-hover:shadow-[0_0_24px_rgba(245,158,11,0.18)]">
+                      {/* Poster */}
+                      {posterSrc ? (
+                        <Image
+                          src={posterSrc}
+                          alt={item.title}
+                          fill
+                          sizes="(max-width: 640px) 128px, 144px"
+                          className="object-cover"
+                        />
+                      ) : (
+                        <div className="w-full h-full bg-gray-800 flex items-center justify-center">
+                          <svg className="w-8 h-8 text-gray-600" fill="currentColor" viewBox="0 0 24 24">
+                            <path d="M10 8.64L15.27 12 10 15.36V8.64M8 5v14l11-7L8 5z" />
+                          </svg>
+                        </div>
+                      )}
+
+                      {/* Dark gradient overlay */}
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent" />
+
+                      {/* Continue badge */}
+                      <div className="absolute top-2 left-2 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-amber-500/90 backdrop-blur-sm">
+                        <svg className="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M8 5v14l11-7L8 5z" />
+                        </svg>
+                        <span className="text-[8px] text-white font-bold leading-none tracking-wider uppercase">
+                          Continue
+                        </span>
+                      </div>
+
+                      {/* Play button — shows on hover */}
+                      <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                        <div className="w-10 h-10 rounded-full bg-white/20 backdrop-blur-sm border border-white/30 flex items-center justify-center">
+                          <PlayIcon />
+                        </div>
+                      </div>
+
+                      {/* Title at bottom */}
+                      <div className="absolute bottom-0 left-0 right-0 p-2">
+                        <p className="text-white text-[11px] font-semibold leading-tight line-clamp-2">
+                          {item.title}
+                        </p>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/TrailerModal.js
+++ b/src/components/ui/TrailerModal.js
@@ -1,101 +1,127 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-const TrailerModal = ({ isOpen, onClose, trailerUrl, movieTitle }) => {
-  // Convert YouTube watch URL to embed URL
-  const getEmbedUrl = (url) => {
-    if (!url) return null;
+let ytApiReady = false;
+let ytApiLoading = false;
+const ytReadyCallbacks = [];
 
-    // Extract video ID from YouTube URL
-    const videoId = url.match(
-      /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/
-    );
-    if (videoId && videoId[1]) {
-      return `https://www.youtube.com/embed/${videoId[1]}?autoplay=1&rel=0&modestbranding=1`;
-    }
-    return null;
+function loadYouTubeApi(cb) {
+  if (ytApiReady) { cb(); return; }
+  ytReadyCallbacks.push(cb);
+  if (ytApiLoading) return;
+  ytApiLoading = true;
+  window.onYouTubeIframeAPIReady = () => {
+    ytApiReady = true;
+    ytReadyCallbacks.forEach((fn) => fn());
+    ytReadyCallbacks.length = 0;
   };
+  const script = document.createElement("script");
+  script.src = "https://www.youtube.com/iframe_api";
+  document.head.appendChild(script);
+}
 
-  // Handle ESC key to close modal
+function extractVideoId(url) {
+  if (!url) return null;
+  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/);
+  return match?.[1] ?? null;
+}
+
+const TrailerModal = ({ isOpen, onClose, trailerUrl, movieTitle, onCompleted }) => {
+  const playerContainerRef = useRef(null);
+  const playerRef = useRef(null);
+
+  // Block body scroll when open
   useEffect(() => {
-    const handleEsc = (event) => {
-      if (event.keyCode === 27) {
-        onClose();
-      }
-    };
-
+    const handleEsc = (e) => { if (e.keyCode === 27) onClose(); };
     if (isOpen) {
       document.addEventListener("keydown", handleEsc);
-      // Prevent body scroll when modal is open
       document.body.style.overflow = "hidden";
     } else {
       document.body.style.overflow = "unset";
     }
-
     return () => {
       document.removeEventListener("keydown", handleEsc);
       document.body.style.overflow = "unset";
     };
   }, [isOpen, onClose]);
 
+  // Create/destroy YT player when modal opens/closes
+  useEffect(() => {
+    if (!isOpen) {
+      if (playerRef.current) {
+        try { playerRef.current.destroy(); } catch (_) {}
+        playerRef.current = null;
+      }
+      return;
+    }
+
+    const videoId = extractVideoId(trailerUrl);
+    if (!videoId || !playerContainerRef.current) return;
+
+    loadYouTubeApi(() => {
+      if (!playerContainerRef.current) return;
+      // Clear previous content
+      playerContainerRef.current.innerHTML = "";
+      const div = document.createElement("div");
+      playerContainerRef.current.appendChild(div);
+
+      playerRef.current = new window.YT.Player(div, {
+        videoId,
+        width: "100%",
+        height: "100%",
+        playerVars: { autoplay: 1, rel: 0, modestbranding: 1 },
+        events: {
+          onStateChange: (event) => {
+            // YT.PlayerState.ENDED === 0
+            if (event.data === 0 && onCompleted) {
+              onCompleted();
+            }
+          },
+        },
+      });
+    });
+
+    return () => {
+      if (playerRef.current) {
+        try { playerRef.current.destroy(); } catch (_) {}
+        playerRef.current = null;
+      }
+    };
+  }, [isOpen, trailerUrl, onCompleted]);
+
   if (!isOpen) return null;
 
-  const embedUrl = getEmbedUrl(trailerUrl);
+  const videoId = extractVideoId(trailerUrl);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-[#141414]  bg-opacity-80"
-        onClick={onClose}
-      />
+      <div className="absolute inset-0 bg-[#141414] bg-opacity-80" onClick={onClose} />
 
-      {/* Modal Content */}
       <div className="relative w-full max-w-6xl mx-4 bg-[#141414] rounded-lg overflow-hidden shadow-2xl">
-        {/* Header */}
         <div className="flex items-center justify-between p-4 bg-gray-900">
           <h2 className="text-white text-xl font-semibold">
             {movieTitle} - Trailer
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-white transition-colors p-2"
+            className="text-gray-400 hover:text-white transition-colors p-2 cursor-pointer"
             aria-label="Close modal"
           >
-            <svg
-              className="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
 
-        {/* Video Container */}
         <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
-          {embedUrl ? (
-            <iframe
-              src={embedUrl}
-              title={`${movieTitle} Trailer`}
-              frameBorder="0"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowFullScreen
+          {videoId ? (
+            <div
+              ref={playerContainerRef}
               className="absolute top-0 left-0 w-full h-full"
             />
           ) : (
             <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center bg-gray-800">
               <div className="text-center text-white">
-                <svg
-                  className="w-16 h-16 mx-auto mb-4 text-gray-400"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
+                <svg className="w-16 h-16 mx-auto mb-4 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M10 8.64L15.27 12 10 15.36V8.64M8 5v14l11-7L8 5z" />
                 </svg>
                 <p className="text-lg">Trailer not available</p>

--- a/src/pages/api/trailerHistory.js
+++ b/src/pages/api/trailerHistory.js
@@ -14,8 +14,13 @@ export default async function handler(req, res) {
 
   if (req.method === "GET") {
     try {
+      const { status } = req.query;
+      const where = { userId };
+      if (status === "incomplete") where.completed = false;
+      else if (status === "complete") where.completed = true;
+
       const history = await prisma.trailerWatch.findMany({
-        where: { userId },
+        where,
         orderBy: { watchedAt: "desc" },
         take: 20,
       });
@@ -28,32 +33,49 @@ export default async function handler(req, res) {
 
   if (req.method === "POST") {
     try {
-      const { tmdbId, mediaType = "movie", title, poster } = req.body || {};
+      const { tmdbId, mediaType = "movie", title, poster, completed = false } = req.body || {};
       if (!tmdbId || !title) {
         return res.status(400).json({ message: "tmdbId and title are required" });
       }
 
       const record = await prisma.trailerWatch.upsert({
         where: {
-          userId_tmdbId_mediaType: {
-            userId,
-            tmdbId: String(tmdbId),
-            mediaType,
-          },
+          userId_tmdbId_mediaType: { userId, tmdbId: String(tmdbId), mediaType },
         },
-        update: { watchedAt: new Date() },
+        update: { watchedAt: new Date(), completed },
         create: {
           userId,
           tmdbId: String(tmdbId),
           mediaType,
           title,
           poster: poster || null,
+          completed,
         },
       });
 
       return res.status(200).json({ success: true, item: record });
     } catch (e) {
       console.error("Record trailer watch error:", e);
+      return res.status(500).json({ message: "Internal server error" });
+    }
+  }
+
+  // Mark a specific trailer as completed
+  if (req.method === "PATCH") {
+    try {
+      const { tmdbId, mediaType = "movie" } = req.body || {};
+      if (!tmdbId) {
+        return res.status(400).json({ message: "tmdbId is required" });
+      }
+
+      const record = await prisma.trailerWatch.updateMany({
+        where: { userId, tmdbId: String(tmdbId), mediaType },
+        data: { completed: true },
+      });
+
+      return res.status(200).json({ success: true, updated: record.count });
+    } catch (e) {
+      console.error("Mark trailer complete error:", e);
       return res.status(500).json({ message: "Internal server error" });
     }
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import { movieApiConfig } from "../../config/apiConfig";
 import { Header, MovieGrid } from "../components";
 import HomepageHero from "../components/ui/HomepageHero";
+import ContinueWatchingCarousel from "../components/ui/ContinueWatchingCarousel";
 import Head from "next/head";
 
 export async function getServerSideProps() {
@@ -90,6 +91,9 @@ export default function Home({ heroMovies }) {
 
         {/* Full-viewport hero with trending feature */}
         <HomepageHero movies={heroMovies} />
+
+        {/* Continue Watching — only shown to logged-in users with incomplete trailers */}
+        <ContinueWatchingCarousel />
 
         {/* Content rows */}
         <MovieGrid rows={allRows} />

--- a/src/pages/moviedetails/[msid]/index.js
+++ b/src/pages/moviedetails/[msid]/index.js
@@ -177,6 +177,13 @@ const MovieDetails = () => {
           onClose={() => setIsTrailerModalOpen(false)}
           trailerUrl={movie?.trailer}
           movieTitle={movie?.title}
+          onCompleted={() => {
+            fetch("/api/trailerHistory", {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ tmdbId: String(movie.id), mediaType: "movie" }),
+            }).catch(() => {});
+          }}
         />
       </div>
     </>

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -614,8 +614,26 @@ export default function Profile() {
                   <Link href={href}>
                     <MovieCard movie={movie} forList />
                   </Link>
-                  {/* Play badge overlay */}
-                  <div className="absolute top-2 left-2 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/70 backdrop-blur-sm pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                  {/* Status badge — always visible */}
+                  <div className="absolute top-2 left-2 right-2 flex items-center justify-between pointer-events-none">
+                    {item.completed ? (
+                      <span className="flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-emerald-600/90 backdrop-blur-sm">
+                        <svg className="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                        </svg>
+                        <span className="text-[9px] text-white font-semibold leading-none tracking-wide">WATCHED</span>
+                      </span>
+                    ) : (
+                      <span className="flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-amber-500/90 backdrop-blur-sm">
+                        <svg className="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M8 5v14l11-7L8 5z" />
+                        </svg>
+                        <span className="text-[9px] text-white font-semibold leading-none tracking-wide">CONTINUE</span>
+                      </span>
+                    )}
+                  </div>
+                  {/* Time ago — on hover */}
+                  <div className="absolute bottom-2 left-2 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/70 backdrop-blur-sm pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-200">
                     <PlayIcon className="w-3 h-3 text-rose-400" />
                     <span className="text-[10px] text-rose-300 font-medium leading-none">
                       {timeAgo(item.watchedAt)}

--- a/src/pages/tvdetails/[msid]/index.js
+++ b/src/pages/tvdetails/[msid]/index.js
@@ -189,6 +189,13 @@ const TVDetails = () => {
           onClose={() => setIsTrailerModalOpen(false)}
           trailerUrl={tvShow?.trailer}
           movieTitle={tvShow?.title}
+          onCompleted={() => {
+            fetch("/api/trailerHistory", {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ tmdbId: String(tvShow.id), mediaType: "tv" }),
+            }).catch(() => {});
+          }}
         />
       </div>
     </>


### PR DESCRIPTION
- Add `completed` boolean field to TrailerWatch Prisma model
- TrailerModal now uses YouTube IFrame API to detect video end event (state 0); fires onCompleted callback when trailer finishes playing
- Movie and TV detail pages pass onCompleted handler that PATCHes the trailer record as completed
- /api/trailerHistory gains a PATCH endpoint to mark a trailer complete, and GET supports ?status=incomplete|complete filtering
- Profile page shows persistent WATCHED (green) / CONTINUE (amber) badges on each trailer card
- New ContinueWatchingCarousel component on homepage: cinematic dark cards with amber accents, scroll arrows, and snap scrolling; only renders for logged-in users who have unfinished trailers